### PR TITLE
Remove dependence on Rails gem (ActiveSupport)

### DIFF
--- a/lazada.gemspec
+++ b/lazada.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "builder", '~> 3.1.4'
   spec.add_dependency "httparty", "~> 0.13.7"
-  spec.add_dependency "activesupport", "~> 4.2"
+  spec.add_dependency "addressable", "~> 2.5.2"
 
   spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/lib/lazada/client.rb
+++ b/lib/lazada/client.rb
@@ -1,5 +1,6 @@
 require 'httparty'
 require 'active_support/core_ext/hash'
+require 'addressable/uri'
 
 require 'lazada/api/product'
 require 'lazada/api/category'
@@ -41,13 +42,16 @@ module Lazada
         'Version' => '1.0'
       }
 
+      parameters['Filter'] = '' if parameters['Filter'].nil?
+
       parameters = parameters.merge(options) if options.present?
-
       parameters = Hash[parameters.sort{ |a, b| a[0] <=> b[0] }]
-      params     = parameters.to_query
 
-      signature = OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('sha256'), @api_key, params)
-      url = "/?#{params}&Signature=#{signature}"
+      uri = Addressable::URI.new
+      uri.query_values = parameters
+
+      signature = OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('sha256'), @api_key, uri.query)
+      url = "/?#{uri.query}&Signature=#{signature}"
     end
 
   end


### PR DESCRIPTION
Currently, this gem depends on ActiveSupport gem (which is just rails) just to use .to_query method.

I have removed the dependency on a rails gem and replace it with `addressable` 